### PR TITLE
Implement /join command

### DIFF
--- a/config/settings.json.example
+++ b/config/settings.json.example
@@ -9,5 +9,6 @@
   "provider_type": "level",
   "redis_url": "redis://ip:port",
   "enable_tts_channels": false,
+  "join_on_tts_channel_message_send": true,
   "enable_keep_alive": false
 }

--- a/src/commands/main/all-tts/JoinCommand.js
+++ b/src/commands/main/all-tts/JoinCommand.js
@@ -1,0 +1,48 @@
+const { SlashCommand } = require('@greencoast/discord.js-extended');
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const logger = require('@greencoast/logger');
+const { getCantConnectToChannelReason } = require('../../../utils/channel');
+
+class JoinCommand extends SlashCommand {
+  constructor(client) {
+    super(client, {
+      name: 'join',
+      description: 'Makes the bot join the current user\'s voice channel.',
+      emoji: ':fast_forward:',
+      group: 'all-tts',
+      guildOnly: true,
+      dataBuilder: new SlashCommandBuilder()
+    });
+  }
+
+  getProviderName(currentSettings) {
+    return currentSettings.provider;
+  }
+
+  async run(interaction) {
+    await interaction.deferReply({ ephemeral: true });
+
+    const localizer = this.client.localizer.getLocalizer(interaction.guild);
+    const ttsPlayer = this.client.getTTSPlayer(interaction.guild);
+    const connection = ttsPlayer.voice.getConnection();
+
+    const { name: guildName } = interaction.guild;
+    const { channel: memberChannel } = interaction.member.voice;
+
+    const cantConnectReason = getCantConnectToChannelReason(memberChannel);
+    if (!memberChannel || cantConnectReason) {
+      await interaction.editReply(cantConnectReason ? localizer.t(cantConnectReason) : localizer.t('command.join.no_channel'));
+      return;
+    }
+
+    if (!connection) {
+      await ttsPlayer.voice.connect(memberChannel);
+      logger.info(`Joined ${memberChannel.name} in ${guildName}.`);
+      await interaction.editReply(localizer.t('command.join.joined', { channel: memberChannel.toString() }));
+    } else {
+      await interaction.editReply(localizer.t('command.join.already_connected'));
+    }
+  }
+}
+
+module.exports = JoinCommand;

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -29,6 +29,10 @@ const COMMAND = {
   'command.say.success': 'I will say that now.',
   'command.say.joined': 'Joined {channel}.',
 
+  'command.join.no_channel': 'You need to be in a voice channel first.',
+  'command.join.joined': 'Joined {channel}.',
+  'command.join.already_connected': 'I am already in a voice channel.',
+
   'command.stop.no_connection': "I'm not in a voice channel.",
   'command.stop.different_channel': 'You need to be in my voice channel to stop me.',
   'command.stop.success': 'Successfully left the voice channel {channel}.',


### PR DESCRIPTION
### :pencil: Checklist

Make sure that your PR fulfills these requirements:

- [X] Code has been linted with the proper rules.

### :page_facing_up: Description

Adds a `/join` command to the bot so the bot can join (without needing for someone to make the bot say something) - useful for TTS channels. Also adds a new config option that changes whether the bot joins the channel automatically if a user sends a message in a TTS bot channel.

### :pushpin: Does this PR address any issue?

N/A
